### PR TITLE
Bump the .so version to 10 (bsc#1132247)

### DIFF
--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,11 +1,11 @@
 SET( VERSION_MAJOR "2" )
-SET( VERSION_MINOR "43" )
-SET( VERSION_PATCH "6" )
+SET( VERSION_MINOR "44" )
+SET( VERSION_PATCH "0" )
 SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" )
 
 ##### This is need for the libyui core, ONLY.
 ##### These will be overridden from exports in LibyuiConfig.cmake
-SET( SONAME_MAJOR "5" )
+SET( SONAME_MAJOR "0" )
 SET( SONAME_MINOR "0" )
 SET( SONAME_PATCH "0" )
 SET( SONAME "${SONAME_MAJOR}.${SONAME_MINOR}.${SONAME_PATCH}" )

--- a/package/libyui-gtk-pkg-doc.spec
+++ b/package/libyui-gtk-pkg-doc.spec
@@ -17,10 +17,10 @@
 
 
 %define parent libyui-gtk-pkg
-%define so_version 9
+%define so_version 10
 
 Name:           %{parent}-doc
-Version:        2.43.6
+Version:        2.44.0
 Release:        0
 Source:         %{parent}-%{version}.tar.bz2
 
@@ -31,7 +31,7 @@ BuildRequires:  doxygen
 BuildRequires:  fdupes
 BuildRequires:  gcc-c++
 BuildRequires:  graphviz-gnome
-BuildRequires:  libyui-devel >= 3.0.4
+BuildRequires:  libyui-devel >= 3.5.0
 BuildRequires:  texlive-latex
 
 Url:            http://github.com/libyui/

--- a/package/libyui-gtk-pkg.changes
+++ b/package/libyui-gtk-pkg.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr 12 06:59:41 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Bump the .so version to 10 to be compatible with the other
+  libyui packages (bsc#1132247)
+- 2.44.0
+
+-------------------------------------------------------------------
 Tue Aug 21 10:42:54 CEST 2018 - schubi@suse.de
 
 - Changed dir of COPYING file.

--- a/package/libyui-gtk-pkg.spec
+++ b/package/libyui-gtk-pkg.spec
@@ -17,18 +17,18 @@
 
 
 Name:           libyui-gtk-pkg
-Version:        2.43.6
+Version:        2.44.0
 Release:        0
 Source:         %{name}-%{version}.tar.bz2
 
-%define so_version 9
+%define so_version 10
 %define bin_name %{name}%{so_version}
 
 BuildRequires:  boost-devel
 BuildRequires:  cmake >= 2.8
 BuildRequires:  gcc-c++
 BuildRequires:  gtk3-devel
-BuildRequires:  libyui-devel >= 3.0.4
+BuildRequires:  libyui-devel >= 3.5.0
 BuildRequires:  pkg-config
 
 %define libyui_gtk_devel_version libyui-gtk-devel >= 2.42.0


### PR DESCRIPTION
- to be compatible with the other libyui packages
- Travis fails as it depends on the new libyui base, it builds fine in https://build.opensuse.org/project/monitor/home:lslezak:libyui-rest-api
- 2.44.0